### PR TITLE
fix/routes: Fix assign and get operation detail

### DIFF
--- a/routes/key.js
+++ b/routes/key.js
@@ -1,7 +1,7 @@
 const { Router } = require('express');
 const asyncHandler = require('express-async-handler');
 const { body } = require('express-validator');
-const { pick } = require('lodash');
+const { pick, assign } = require('lodash');
 const Key = require('../models/key');
 const validator = require('../middlewares/validator');
 

--- a/routes/operation.js
+++ b/routes/operation.js
@@ -103,12 +103,17 @@ router.param('id', asyncHandler(async function (req, res, next) {
   next();
 }));
 
-router.get('/:id', function (req, res) {
-  res.json(assign(pick(req.operation, ATTRIBUTES), {
-    data: req.operation.data.toString('hex'),
-    signature: req.operation.signature.toString('hex'),
+router.get('/:id', asyncHandler(async function (req, res) {
+  const operation = await Operation.findOne({
+    where: {
+      id: req.params.id,
+    },
+  });
+  res.json(assign(pick(operation, ATTRIBUTES), {
+    data: operation.data && operation.data.toString('hex'),
+    signature: operation.signature && operation.signature.toString('hex'),
   }));
-});
+}));
 
 router.put('/:id', validator([
   body('message')

--- a/routes/operation.js
+++ b/routes/operation.js
@@ -103,17 +103,12 @@ router.param('id', asyncHandler(async function (req, res, next) {
   next();
 }));
 
-router.get('/:id', asyncHandler(async function (req, res) {
-  const operation = await Operation.findOne({
-    where: {
-      id: req.params.id,
-    },
-  });
-  res.json(assign(pick(operation, ATTRIBUTES), {
-    data: operation.data && operation.data.toString('hex'),
-    signature: operation.signature && operation.signature.toString('hex'),
+router.get('/:id', function (req, res) {
+  res.json(assign(pick(req.operation, ATTRIBUTES), {
+    data: req.operation.data && req.operation.data.toString('hex'),
+    signature: req.operation.signature && req.operation.signature.toString('hex'),
   }));
-}));
+});
 
 router.put('/:id', validator([
   body('message')


### PR DESCRIPTION
- `assign` from lodash is missing from routes/key.js causes it unable to serve
    https://github.com/nguyenkha/mpc-demo/blob/9f3f4f21287f155de074d67f30358aa38427d88f/routes/key.js#L49-L53
- `data` and `details` in a Operation might have null value, for example: https://mpc.cosset.cf/keys/07b1a685-cd63-4dbb-9c3d-4a04f0a97990/operations/b07ac66e-5790-4832-9cb3-166a8e79366d, this check will handle these edge cases.